### PR TITLE
Add basic maximize support

### DIFF
--- a/include/labwc.h
+++ b/include/labwc.h
@@ -162,6 +162,7 @@ struct view_impl {
 	void (*map)(struct view *view);
 	void (*move)(struct view *view, double x, double y);
 	void (*unmap)(struct view *view);
+	void (*maximize)(struct view *view, bool maximize);
 };
 
 struct border {
@@ -188,6 +189,7 @@ struct view {
 	bool mapped;
 	bool been_mapped;
 	bool minimized;
+	bool maximized;
 
 	/* geometry of the wlr_surface contained within the view */
 	int x, y, w, h;
@@ -224,6 +226,7 @@ struct view {
 	struct wl_listener request_move;
 	struct wl_listener request_resize;
 	struct wl_listener request_configure;
+	struct wl_listener request_maximize;
 	struct wl_listener new_popup; /* xdg-shell only */
 };
 
@@ -266,6 +269,7 @@ void view_move_resize(struct view *view, struct wlr_box geo);
 void view_move(struct view *view, double x, double y);
 void view_minimize(struct view *view);
 void view_unminimize(struct view *view);
+void view_maximize(struct view *view, bool maximize);
 void view_for_each_surface(struct view *view,
 	wlr_surface_iterator_func_t iterator, void *user_data);
 void view_for_each_popup(struct view *view,
@@ -281,8 +285,8 @@ void desktop_focus_view(struct seat *seat, struct view *view);
 struct view *desktop_cycle_view(struct server *server, struct view *current);
 void desktop_focus_topmost_mapped_view(struct server *server);
 struct view *desktop_view_at(struct server *server, double lx, double ly,
-			     struct wlr_surface **surface, double *sx,
-			     double *sy, int *view_area);
+			    struct wlr_surface **surface, double *sx,
+			    double *sy, int *view_area);
 
 void cursor_init(struct seat *seat);
 
@@ -294,7 +298,7 @@ void seat_focus_surface(struct seat *seat, struct wlr_surface *surface);
 void seat_set_focus_layer(struct seat *seat, struct wlr_layer_surface_v1 *layer);
 
 void interactive_begin(struct view *view, enum input_mode mode,
-		       uint32_t edges);
+		      uint32_t edges);
 
 void output_init(struct server *server);
 void output_damage_surface(struct output *output, struct wlr_surface *surface,

--- a/src/cursor.c
+++ b/src/cursor.c
@@ -320,6 +320,9 @@ cursor_button(struct wl_listener *listener, void *data)
 	case LAB_DECO_PART_TITLE:
 		interactive_begin(view, LAB_INPUT_STATE_MOVE, 0);
 		break;
+	case LAB_DECO_BUTTON_MAXIMIZE:
+		view_maximize(view, !view->maximized);
+		break;
 	}
 }
 

--- a/src/view.c
+++ b/src/view.c
@@ -1,5 +1,7 @@
 #include "labwc.h"
 
+#include <stdio.h>
+#include <assert.h>
 void
 view_move_resize(struct view *view, struct wlr_box geo)
 {
@@ -30,6 +32,71 @@ view_unminimize(struct view *view)
 	}
 	view->minimized = false;
 	view->impl->map(view);
+}
+
+void
+view_maximize(struct view *view, bool maximize)
+{
+	if(maximize == true)
+	{
+		struct wlr_output_layout *layout = view->server->output_layout;
+		struct wlr_output* output =
+			wlr_output_layout_output_at(layout, view->x, view->y);
+		struct wlr_output_layout_output* ol_output =
+			wlr_output_layout_get(layout, output);
+
+		assert(layout);
+		if(output == NULL)
+		{
+			die("output NULL w/ x and y of: %d, %d", view->x, view->y);
+		}
+		assert(output);
+		assert(ol_output);
+
+		int x = ol_output->x;
+		int y = ol_output->y;
+		int width = output->width;
+		int height = output->height;
+
+		if(view->server_side_deco)
+		{
+			struct border border = deco_thickness(view);
+			x += border.right;
+			x += border.left;
+			y += border.top;
+			y += border.bottom;
+
+			width -= border.right;
+			width -= border.left;
+			height -= border.top;
+			height -= border.bottom;
+		}
+
+		struct wlr_box box = {
+			.x = x * output->scale,
+			.y = y * output->scale,
+			.width = width * output->scale,
+			.height = height * output->scale
+		};
+
+		view_move_resize(view, box);
+		view_move(view, box.x * output->scale, box.y * output->scale);
+
+		view->maximized = true;
+	}
+	else
+	{
+		struct wlr_box box = {
+			.x = 20,
+			.y = 50,
+			.width = 640,
+			.height = 480
+		};
+
+		view_move_resize(view, box);
+		view->maximized = false;
+	}
+	view->impl->maximize(view, maximize);
 }
 
 void


### PR DESCRIPTION
The maximize button on SSD works and the maximize button and double-clicking the title bar works on CSD

TODO: It currently does not factor taskbars (I tested with waybar) into account, and when unmaximizing a window it does not remember what the previous location or size was