### PR TITLE
Allow downstream to disable manpages even if pandoc is found

### DIFF
--- a/docs/meson.build
+++ b/docs/meson.build
@@ -1,4 +1,4 @@
-pandoc = find_program('pandoc', required: false)
+pandoc = find_program('pandoc', required: get_option('man-pages'))
 
 sections = ['.1', '-config.5', '-theme.5', '-actions.5']
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,1 +1,2 @@
+option('man-pages', type: 'feature', value: 'auto', description: 'Generate and install man pages')
 option('xwayland', type: 'feature', value: 'auto', description: 'Enable support for X11 applications')


### PR DESCRIPTION
See swaywm/sway#3452. To be used by Gentoo and [FreeBSD](https://github.com/freebsd/freebsd-ports/commit/d1251e059251dd28901b71374eb78b5c68514cc3).

```
$ pkg install hs-pandoc
$ meson setup -Dman-pages=disabled _build
[...]
Program pandoc skipped: feature man-pages disabled
[...]
```
