### PR TITLE
docs: move manpages to proper section directories

### DIFF
--- a/docs/meson.build
+++ b/docs/meson.build
@@ -12,7 +12,7 @@ if pandoc.found()
       output: manpage,
       capture: true,
       install: true,
-      install_dir: join_paths(get_option('mandir'), 'man' + s)
+      install_dir: join_paths(get_option('mandir'), 'man' + s.split('.')[-1])
     )
   endforeach
 endif


### PR DESCRIPTION
Manpages may not be accessible by `man` command. [Affects](https://github.com/freebsd/freebsd-ports/commit/f633acc8477c5d07c28eab9353e56ed028d3012d) at least [FreeBSD](https://github.com/freebsd/freebsd-src/blob/releng/13.0/usr.bin/man/man.sh#L1015).
```
$ meson setup --prefix=/usr _build && meson install -C _build
[...]
Installing docs/labwc.1 to /usr/share/man/man.1
Installing docs/labwc-config.5 to /usr/share/man/man-config.5
Installing docs/labwc-theme.5 to /usr/share/man/man-theme.5
Installing docs/labwc-actions.5 to /usr/share/man/man-actions.5
[...]
$ man labwc
No manual entry for labwc
$ man labwc-config
No manual entry for labwc-config
```