### PR TITLE
Unbreak build with system wlroots 0.13

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -47,7 +47,7 @@ if wlroots_proj.found()
   wlroots_conf = wlroots_proj.get_variable('conf_data')
   wlroots_has_xwayland = wlroots_conf.get('WLR_HAS_XWAYLAND') == 1
 else
-  wlroots       = dependency('wlroots', version: '>=0.13.0', '<0.14.0')
+  wlroots       = dependency('wlroots', version: ['>=0.13.0', '<0.14.0'])
   wlroots_has_xwayland = cc.get_define('WLR_HAS_XWAYLAND', prefix: '#include <wlr/config.h>', dependencies: wlroots) == '1'
 endif
 wayland_server  = dependency('wayland-server', version: '>=0.19.0')


### PR DESCRIPTION
Regressed by fd4ea3542fdc. From [error log](https://github.com/johanmalm/labwc/files/6321069/labwc-0.2.0.log):
```
Neither a subproject directory nor a wlroots.wrap file was found.
Subproject  wlroots is buildable: NO (disabling)

meson.build:50:2: ERROR: All keyword arguments must be after positional arguments.
```
