### PR TITLE
focus: add basic follow mouse support

### DIFF
--- a/include/config/rcxml.h
+++ b/include/config/rcxml.h
@@ -9,6 +9,8 @@
 
 struct rcxml {
 	bool xdg_shell_server_side_deco;
+	bool focus_follow_mouse;
+	bool raise_on_focus;
 	char *theme_name;
 	int corner_radius;
 	char *font_name_activewindow;

--- a/include/labwc.h
+++ b/include/labwc.h
@@ -296,6 +296,7 @@ void view_for_each_surface(struct view *view,
 void view_for_each_popup_surface(struct view *view,
 	wlr_surface_iterator_func_t iterator, void *data);
 
+void desktop_set_focus_view_only(struct seat *seat, struct view *view);
 void desktop_focus_view(struct seat *seat, struct view *view);
 
 /**

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -138,6 +138,11 @@ entry(xmlNode *node, char *nodename, char *content)
 		fill_font(nodename, content, font_place);
 	} else if (!strcmp(nodename, "size.font.theme")) {
 		fill_font(nodename, content, font_place);
+	} else if (!strcasecmp(nodename, "FollowMouse.focus")) {
+		rc.focus_follow_mouse = get_bool(content);
+	} else if (!strcasecmp(nodename, "RaisemOnFocus.focus")) {
+		rc.focus_follow_mouse = true;
+		rc.raise_on_focus = get_bool(content);
 	}
 }
 

--- a/src/cursor.c
+++ b/src/cursor.c
@@ -152,6 +152,15 @@ process_cursor_motion(struct server *server, uint32_t time)
 		uint32_t resize_edges = get_resize_edges(
 			view, server->seat.cursor->x, server->seat.cursor->y);
 		switch (resize_edges) {
+		case 0:
+			if (rc.focus_follow_mouse){
+				if (rc.raise_on_focus){
+					desktop_focus_view(&server->seat, view);
+				} else {
+					desktop_set_focus_view_only(&server->seat, view);
+				}
+			}
+			break;
 		case WLR_EDGE_TOP:
 			cursor_name = "top_side";
 			break;


### PR DESCRIPTION
There is no plans to support focus follow mouse mode, but I use it. So I decide to implement it in this openbox clone.