### PR TITLE
meson: Use wrap files to manage dependencies

### DIFF
--- a/subprojects/seatd.wrap
+++ b/subprojects/seatd.wrap
@@ -1,0 +1,4 @@
+[wrap-git]
+url=https://git.sr.ht/~kennylevinsen/seatd
+revision=master
+

--- a/subprojects/wlroots.wrap
+++ b/subprojects/wlroots.wrap
@@ -1,0 +1,3 @@
+[wrap-git]
+url = https://github.com/swaywm/wlroots
+revision = master


### PR DESCRIPTION
This simplifies building as there's no need to manually
git clone subprojects anymore.