### PR TITLE
meson: bump wlroots dependency version number

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -36,7 +36,7 @@ if git.found()
 endif
 add_project_arguments('-DLABWC_VERSION=@0@'.format(version), language: 'c')
 
-wlroots_version = ['>=0.14.0', '<0.15.0']
+wlroots_version = ['>=0.14.0', '<=0.15.0']
 wlroots_proj = subproject(
   'wlroots',
   default_options: ['examples=false'],


### PR DESCRIPTION
did not build with '<0.15.0', so bumped to  '<=0.15.0'