### PR TITLE
workaround Gtk primary selection bug by changing order of globals

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -156,6 +156,17 @@ server_init(struct server *server)
 		exit(EXIT_FAILURE);
 	}
 
+	/* empirically, primary selection doesn't work with Gtk apps unless the
+	 * device manager is one of the earliest globals to be advertised. All
+	 * credit to Wayfire for discovering this, though their symptoms
+	 * (crash) are not the same as ours (silently does nothing). When adding
+	 * more globals above this line it would be as well to check that
+	 * middle-button paste still works with any Gtk app of your choice
+	 *
+	 * https://wayfire.org/2020/08/04/Wayfire-0-5.html
+	*/
+	wlr_primary_selection_v1_device_manager_create(server->wl_display);
+
 	output_init(server);
 	seat_init(server);
 
@@ -195,7 +206,6 @@ server_init(struct server *server)
 	wlr_screencopy_manager_v1_create(server->wl_display);
 	wlr_data_control_manager_v1_create(server->wl_display);
 	wlr_gamma_control_manager_v1_create(server->wl_display);
-	wlr_primary_selection_v1_device_manager_create(server->wl_display);
 
 	server->foreign_toplevel_manager =
 		wlr_foreign_toplevel_manager_v1_create(server->wl_display);


### PR DESCRIPTION
This makes primary selections work at least with wayland-native Emacs (using the pgtk backend) and Firefox. I haven't tested others.

I can't claim credit for fixing this. I found the following in a Wayfire release notes page

> primary-selection protocol

> This protocol is needed for middle-click-paste to work. The implementation of the protocol is mostly done by wlroots, so Wayfire needs just a couple of lines for it to work. However, enabling it initially caused crashes in all GTK applications. After hours of debuggingg, it turned out to be a bug in GTK3, and I had to change the ordering of globals (wayland protocol objects) so that the primary-selection global is one of the first advertised. Phew!

and although the symptoms aren't the same, the fix seems to work anyway
https://wayfire.org/2020/08/04/Wayfire-0-5.html
