### PR TITLE
fix madly flashing background

### DIFF
--- a/src/output.c
+++ b/src/output.c
@@ -661,7 +661,7 @@ output_render(struct output *output, pixman_region32_t *damage)
 		goto renderer_end;
 	}
 
-#ifdef DEBUG
+#if DEBUG
 	wlr_renderer_clear(renderer, (float[]){0.2f, 0.0f, 0.0f, 1.0f});
 #endif
 


### PR DESCRIPTION
Symptom: the screen outside of the active window intermittently blanks and unblanks (looks like it's correlated somehow with mouse pointer events)

Cause: style cleanups in ea3ea497837f  changed the use of the preprocessor symbol DEBUG, which is now defined to (0) even when debugging should not not be enabled, so change from testing it with `#ifdef` to `#if`