### PR TITLE
Specify GPL-2.0-only

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -2,7 +2,7 @@ project(
   'labwc',
   'c',
   version: '0.3.0',
-  license: 'GPL-2',
+  license: 'GPL-2.0-only',
   default_options: [
     'c_std=c11',
     'warning_level=2',


### PR DESCRIPTION
If `-or-later` is not specified, it can be generally assumed that it's `-only`, this however makes it clear.