### PR TITLE
improve actions

### DIFF
--- a/include/labwc.h
+++ b/include/labwc.h
@@ -338,6 +338,7 @@ void desktop_focus_view(struct seat *seat, struct view *view);
  */
 struct view *desktop_cycle_view(struct server *server, struct view *current);
 struct view *topmost_mapped_view(struct server *server);
+struct view *focused_view(struct server *server);
 void desktop_focus_topmost_mapped_view(struct server *server);
 bool isfocusable(struct view *view);
 

--- a/include/labwc.h
+++ b/include/labwc.h
@@ -317,6 +317,8 @@ void view_maximize(struct view *view, bool maximize);
 void view_set_fullscreen(struct view *view, bool fullscreen,
 	struct wlr_output *wlr_output);
 void view_toggle_maximize(struct view *view);
+void view_toggle_decorations(struct view *view);
+void view_toggle_fullscreen(struct view *view);
 void view_for_each_surface(struct view *view,
 	wlr_surface_iterator_func_t iterator, void *user_data);
 void view_for_each_popup_surface(struct view *view,

--- a/src/action.c
+++ b/src/action.c
@@ -64,6 +64,11 @@ action(struct server *server, const char *action, const char *command)
 		if (view) {
 			view_toggle_decorations(view);
 		}
+	} else if (!strcasecmp(action, "Iconify")) {
+		struct view *view = topmost_mapped_view(server);
+		if (view) {
+			view_minimize(view, true);
+		}
 	} else {
 		wlr_log(WLR_ERROR, "action (%s) not supported", action);
 	}

--- a/src/action.c
+++ b/src/action.c
@@ -54,6 +54,16 @@ action(struct server *server, const char *action, const char *command)
 		if (view) {
 			view_toggle_maximize(view);
 		}
+	} else if (!strcasecmp(action, "ToggleFullscreen")) {
+		struct view *view = topmost_mapped_view(server);
+		if (view) {
+			view_toggle_fullscreen(view);
+		}
+	} else if (!strcasecmp(action, "ToggleDecorations")) {
+		struct view *view = topmost_mapped_view(server);
+		if (view) {
+			view_toggle_decorations(view);
+		}
 	} else {
 		wlr_log(WLR_ERROR, "action (%s) not supported", action);
 	}

--- a/src/action.c
+++ b/src/action.c
@@ -24,7 +24,7 @@ action(struct server *server, const char *action, const char *command)
 	if (!action)
 		return;
 	if (!strcasecmp(action, "Close")) {
-		struct view *view = topmost_mapped_view(server);
+		struct view *view = focused_view(server);
 		if (view) {
 			view->impl->close(view);
 		}
@@ -40,7 +40,7 @@ action(struct server *server, const char *action, const char *command)
 	} else if (!strcasecmp(action, "Exit")) {
 		wl_display_terminate(server->wl_display);
 	} else if (!strcasecmp(action, "MoveToEdge")) {
-		view_move_to_edge(topmost_mapped_view(server), command);
+		view_move_to_edge(focused_view(server), command);
 	} else if (!strcasecmp(action, "NextWindow")) {
 		server->cycle_view =
 			desktop_cycle_view(server, server->cycle_view);
@@ -50,22 +50,22 @@ action(struct server *server, const char *action, const char *command)
 	} else if (!strcasecmp(action, "ShowMenu")) {
 		show_menu(server, command);
 	} else if (!strcasecmp(action, "ToggleMaximize")) {
-		struct view *view = topmost_mapped_view(server);
+		struct view *view = focused_view(server);
 		if (view) {
 			view_toggle_maximize(view);
 		}
 	} else if (!strcasecmp(action, "ToggleFullscreen")) {
-		struct view *view = topmost_mapped_view(server);
+		struct view *view = focused_view(server);
 		if (view) {
 			view_toggle_fullscreen(view);
 		}
 	} else if (!strcasecmp(action, "ToggleDecorations")) {
-		struct view *view = topmost_mapped_view(server);
+		struct view *view = focused_view(server);
 		if (view) {
 			view_toggle_decorations(view);
 		}
 	} else if (!strcasecmp(action, "Iconify")) {
-		struct view *view = topmost_mapped_view(server);
+		struct view *view = focused_view(server);
 		if (view) {
 			view_minimize(view, true);
 		}

--- a/src/desktop.c
+++ b/src/desktop.c
@@ -212,6 +212,25 @@ topmost_mapped_view(struct server *server)
 	return view;
 }
 
+struct view *
+focused_view(struct server *server)
+{
+	struct seat *seat = &server->seat;
+	struct wlr_surface *focused_surface;
+	focused_surface = seat->seat->keyboard_state.focused_surface;
+	if (!focused_surface) {
+		return NULL;
+	}
+	struct view *view;
+	wl_list_for_each (view, &server->views, link) {
+		if (view->surface == focused_surface) {
+			return view;
+		}
+	}
+
+	return NULL;
+}
+
 void
 desktop_focus_topmost_mapped_view(struct server *server)
 {

--- a/src/view.c
+++ b/src/view.c
@@ -108,6 +108,19 @@ view_toggle_maximize(struct view *view)
 }
 
 void
+view_toggle_decorations(struct view *view)
+{
+	view->ssd.enabled = !view->ssd.enabled;
+	ssd_update_geometry(view, true);
+}
+
+void
+view_toggle_fullscreen(struct view *view)
+{
+	view_set_fullscreen(view, !view->fullscreen, NULL);
+}
+
+void
 view_set_fullscreen(struct view *view, bool fullscreen,
 		struct wlr_output *wlr_output)
 {


### PR DESCRIPTION
Implements 3 actions present in openbox but not yet implemented in labwc and changes the default target for keyboard actions to the focused window rather than the topmost mapped window.