### PR TITLE
keyboard: Fix cycle view taking precedence over TTY switch

### DIFF
--- a/src/keyboard.c
+++ b/src/keyboard.c
@@ -130,7 +130,7 @@ handle_compositor_keybindings(struct wl_listener *listener,
 	/* Handle compositor key bindings */
 	if (event->state == WL_KEYBOARD_KEY_STATE_PRESSED) {
 		for (int i = 0; i < nsyms; i++) {
-			handled = handle_keybinding(server, modifiers, syms[i]);
+			handled |= handle_keybinding(server, modifiers, syms[i]);
 		}
 	}
 


### PR DESCRIPTION
I had a bug where cycle view would not close and I was unable to switch to a TTY as it was open.

Signed-off-by: Joshua Ashton <joshua@froggi.es>