### PR TITLE
More mousebinding support

### DIFF
--- a/docs/labwc-config.5.scd
+++ b/docs/labwc-config.5.scd
@@ -111,7 +111,16 @@ Configuration must be wrapped in a <labwc_config> root-node.
 
 *<mouse><context name=""><mousebind button="" action="">*
 	Define a mouse binding. Supported context-names include:
-	'TitleBar'.
+	- TitleBar: The area where the title of the window is shown.
+	- Iconify: The button that looks like an underline.
+	- Maximize: The button that looks like a box.
+	- Close: The button that looks like an X.
+
+	Supported mouse actions include:
+	- Press: Pressing the specified button down in the context.
+	- Release: Releasing the specified button in the context.
+	- Click: Pressing and then releasing inside of the the context.
+	- DoubleClick: Two presses within the doubleClickTime.
 
 # LIBINPUT
 

--- a/docs/rc.xml.all
+++ b/docs/rc.xml.all
@@ -118,6 +118,22 @@
         <action name="ToggleMaximize"/>
       </mousebind>
     </context>
+    <context name="Maximize">
+      <mousebind button="Left" action="Click">
+	<action name="ToggleMaximize"/>
+      </mousebind>
+    </context>
+    <context name="Iconify">
+      <mousebind button="left" action="Click">
+        <action name="Iconify"/>
+      </mousebind>
+    </context>
+    <context name="Close">
+      <mousebind button="Left" action="Click">
+        <action name="Close"/>
+      </mousebind>
+    </context>
+
   </mouse>
 
   <!--

--- a/include/config/mousebind.h
+++ b/include/config/mousebind.h
@@ -7,6 +7,9 @@
 enum mouse_event {
 	MOUSE_ACTION_NONE = 0,
 	MOUSE_ACTION_DOUBLECLICK,
+	MOUSE_ACTION_CLICK,
+	MOUSE_ACTION_PRESS,
+	MOUSE_ACTION_RELEASE,
 };
 
 struct mousebind {
@@ -21,6 +24,7 @@ struct mousebind {
 	const char *command;
 
 	struct wl_list link; /* rcxml::mousebinds */
+	bool pressed_in_context; /* used in click events */
 };
 
 enum mouse_event mousebind_event_from_str(const char *str);

--- a/src/config/mousebind.c
+++ b/src/config/mousebind.c
@@ -27,8 +27,14 @@ enum mouse_event
 mousebind_event_from_str(const char *str)
 {
 	assert(str);
-	if (strcasecmp(str, "doubleclick") == 0) {
+	if (!strcasecmp(str, "doubleclick")) {
 		return MOUSE_ACTION_DOUBLECLICK;
+	} else if (!strcasecmp(str, "click")) {
+		return MOUSE_ACTION_CLICK;
+	} else if (!strcasecmp(str, "press")) {
+		return MOUSE_ACTION_PRESS;
+	} else if (!strcasecmp(str, "release")) {
+		return MOUSE_ACTION_RELEASE;
 	}
 	wlr_log(WLR_ERROR, "unknown mouse action (%s)", str);
 	return MOUSE_ACTION_NONE;
@@ -39,6 +45,12 @@ context_from_str(const char *str)
 {
 	if (!strcasecmp(str, "Titlebar")) {
 		return LAB_SSD_PART_TITLEBAR;
+	} else if (!strcasecmp(str, "Close")) {
+		return LAB_SSD_BUTTON_CLOSE;
+	} else if (!strcasecmp(str, "Maximize")) {
+		return LAB_SSD_BUTTON_MAXIMIZE;
+	} else if (!strcasecmp(str, "Iconify")) {
+		return LAB_SSD_BUTTON_ICONIFY;
 	}
 	wlr_log(WLR_ERROR, "unknown mouse context (%s)", str);
 	return LAB_SSD_NONE;

--- a/src/config/rcxml.c
+++ b/src/config/rcxml.c
@@ -466,6 +466,9 @@ static struct {
 	const char *context, *button, *event, *action, *command;
 } mouse_combos[] = {
 	{ "TitleBar", "Left", "DoubleClick", "ToggleMaximize", NULL },
+	{ "Close", "Left", "Click", "Close", NULL },
+	{ "Iconify", "Left", "Click", "Iconify", NULL},
+	{ "Maximize", "Left", "Click", "ToggleMaximize", NULL},
 	{ NULL, NULL, NULL, NULL, NULL },
 };
 


### PR DESCRIPTION
This will add support for the iconify, maximize, and close mouse contexts, as well as for the press, click, release, and double click (already supported) mouse events.
I moved the default actions of the iconify, maximize, and close buttons to click mouse bindings. This felt more natural to me.
I also changed up the formatting of labwc-config(5) a bit because `'TitleBar'` wouldn't display with mandoc's or busybox's man commands. I'm not sure if this is the case for man-db's man.