### PR TITLE
Add support for static wlroots

### DIFF
--- a/include/labwc.h
+++ b/include/labwc.h
@@ -342,7 +342,7 @@ void xwayland_unmanaged_create(struct server *server,
 void view_child_init(struct view_child *child, struct view *view,
 	struct wlr_surface *wlr_surface);
 void view_child_finish(struct view_child *child);
-void subsurface_create(struct view *view, struct wlr_subsurface *wlr_subsurface);
+void view_subsurface_create(struct view *view, struct wlr_subsurface *wlr_subsurface);
 
 void view_set_activated(struct view *view, bool activated);
 struct border view_border(struct view *view);

--- a/meson.build
+++ b/meson.build
@@ -40,7 +40,7 @@ add_project_arguments('-DLABWC_VERSION=@0@'.format(version), language: 'c')
 wlroots_version = ['>=0.15.0', '<0.16.0']
 wlroots_proj = subproject(
   'wlroots',
-  default_options: ['examples=false'],
+  default_options: ['default_library=static', 'examples=false'],
   required: false,
   version: wlroots_version,
 )

--- a/src/subsurface.c
+++ b/src/subsurface.c
@@ -21,7 +21,7 @@ subsurface_handle_destroy(struct wl_listener *listener, void *data)
 }
 
 void
-subsurface_create(struct view *view, struct wlr_subsurface *wlr_subsurface)
+view_subsurface_create(struct view *view, struct wlr_subsurface *wlr_subsurface)
 {
 	struct view_subsurface *subsurface =
 		calloc(1, sizeof(struct view_subsurface));

--- a/src/view-child.c
+++ b/src/view-child.c
@@ -19,7 +19,7 @@ view_child_handle_new_subsurface(struct wl_listener *listener, void *data)
 	struct view_child *child;
 	child = wl_container_of(listener, child, new_subsurface);
 	struct wlr_subsurface *wlr_subsurface = data;
-	subsurface_create(child->parent, wlr_subsurface);
+	view_subsurface_create(child->parent, wlr_subsurface);
 }
 
 void

--- a/src/xdg.c
+++ b/src/xdg.c
@@ -4,7 +4,7 @@
 #include "ssd.h"
 
 /*
- * xdg_popup_create() and subsurface_create() are only called for the
+ * xdg_popup_create() and view_subsurface_create() are only called for the
  * purposes of tracking damage.
  */
 static void
@@ -20,7 +20,7 @@ new_subsurface_notify(struct wl_listener *listener, void *data)
 {
 	struct view *view = wl_container_of(listener, view, new_subsurface);
 	struct wlr_subsurface *wlr_subsurface = data;
-	subsurface_create(view, wlr_subsurface);
+	view_subsurface_create(view, wlr_subsurface);
 }
 
 static bool
@@ -337,11 +337,11 @@ xdg_toplevel_view_map(struct view *view)
 		struct wlr_subsurface *subsurface;
 		wl_list_for_each(subsurface, &view->surface->current.subsurfaces_below,
 				 current.link) {
-			subsurface_create(view, subsurface);
+			view_subsurface_create(view, subsurface);
 		}
 		wl_list_for_each(subsurface, &view->surface->current.subsurfaces_above,
 				 current.link) {
-			subsurface_create(view, subsurface);
+			view_subsurface_create(view, subsurface);
 		}
 
 		view->been_mapped = true;


### PR DESCRIPTION
`server_{init,finish}()` still collide with seatd (at least, with 0.5.0) - I'll fix that in a separate PR.