### PR TITLE
src/debug.c: try to id important elements

### DIFF
--- a/src/debug.c
+++ b/src/debug.c
@@ -4,9 +4,14 @@
 #include "buffer.h"
 #include "labwc.h"
 
-#define INDENT_SIZE (3)
+#define HEADER_CHARS "------------------------------"
 
-static char *
+#define INDENT_SIZE 3
+#define IGNORE_SSD true
+#define IGNORE_MENU true
+#define LEFT_COL_SPACE 35
+
+static const char *
 get_node_type(enum wlr_scene_node_type type)
 {
 	switch (type) {
@@ -24,64 +29,152 @@ get_node_type(enum wlr_scene_node_type type)
 	return "error";
 }
 
-static void
-dump_tree(struct wlr_scene_node *node, int pos, int x, int y)
-{
-	char *type = get_node_type(node->type);
-
-	if (pos) {
-		printf("%*c+-- ", pos, ' ');
-	}
-	printf("%s (%d,%d) [%p]\n", type, x, y, node);
-
-	struct wlr_scene_node *child;
-	wl_list_for_each(child, &node->state.children, state.link) {
-		dump_tree(child, pos + INDENT_SIZE, x + child->state.x,
-			y + child->state.y);
-	}
-}
-
-static char *
+static const char *
 get_layer_name(uint32_t layer)
 {
 	switch (layer) {
 	case ZWLR_LAYER_SHELL_V1_LAYER_BACKGROUND:
-		return "background";
+		return "layer-background";
 	case ZWLR_LAYER_SHELL_V1_LAYER_BOTTOM:
-		return "bottom";
+		return "layer-bottom";
 	case ZWLR_LAYER_SHELL_V1_LAYER_TOP:
-		return "top";
+		return "layer-top";
 	case ZWLR_LAYER_SHELL_V1_LAYER_OVERLAY:
-		return "overlay";
+		return "layer-overlay";
 	default:
 		abort();
+	}
+}
+
+static const char *
+get_view_part(struct view *view, struct wlr_scene_node *node)
+{
+	if (view && node == &view->scene_tree->node) {
+		return "view";
+	}
+	if (view && node == view->scene_node) {
+		return "view->scene_node";
+	}
+	if (!view || !view->ssd.tree) {
+		return NULL;
+	}
+	if (node == &view->ssd.tree->node) {
+		return "view->ssd";
+	}
+	if (node == &view->ssd.titlebar.active.tree->node) {
+		return "titlebar.active";
+	}
+	if (node == &view->ssd.titlebar.inactive.tree->node) {
+		return "titlebar.inactive";
+	}
+	if (node == &view->ssd.border.active.tree->node) {
+		return "border.active";
+	}
+	if (node == &view->ssd.border.inactive.tree->node) {
+		return "border.inactive";
+	}
+	if (node == &view->ssd.extents.tree->node) {
+		return "extents";
+	}
+	return NULL;
+}
+
+static const char *
+get_special(struct server *server, struct wlr_scene_node *node,
+	struct view **last_view)
+{
+	if (node == &server->scene->node) {
+		return "server->scene";
+	}
+	if (node == &server->osd_tree->node) {
+		return "server->osd_tree";
+	}
+	if (node == &server->menu_tree->node) {
+		return "server->menu_tree";
+	}
+	if (node->parent == &server->scene->node) {
+		struct output *output;
+		wl_list_for_each(output, &server->outputs, link) {
+			for (int i = 0; i < 4; i++) {
+				if (node == &output->layer_tree[i]->node) {
+					return get_layer_name(i);
+				}
+			}
+		}
+	}
+#if HAVE_XWAYLAND
+	if (node == &server->unmanaged_tree->node) {
+		return "server->unmanaged_tree";
+	}
+#endif
+	if (node == &server->view_tree->node) {
+		return "server->view_tree";
+	}
+	if (node->parent == &server->view_tree->node) {
+		*last_view = node->data;
+	}
+	const char *view_part = get_view_part(*last_view, node);
+	if (view_part) {
+		return view_part;
+	}
+	return get_node_type(node->type);
+}
+
+struct pad {
+	uint8_t left;
+	uint8_t right;
+};
+
+static struct pad
+get_center_padding(const char *text, uint8_t max_width)
+{
+	struct pad pad;
+	size_t text_len = strlen(text);
+	pad.left = (double)(max_width - text_len) / 2 + 0.5f;
+	pad.right = max_width - pad.left - text_len;
+	return pad;
+}
+
+static void
+dump_tree(struct server *server, struct wlr_scene_node *node,
+	int pos, int x, int y)
+{
+	static struct view *view;
+	const char *type = get_special(server, node, &view);
+
+	if (pos) {
+		printf("%*c+-- ", pos, ' ');
+	} else {
+		struct pad node_pad = get_center_padding("Node", 16);
+		printf(" %*c %4s  %4s  %*c%s\n", LEFT_COL_SPACE + 4, ' ',
+			"X", "Y", node_pad.left, ' ', "Node");
+		printf(" %*c %.4s  %.4s  %.16s\n", LEFT_COL_SPACE + 4, ' ',
+			HEADER_CHARS, HEADER_CHARS, HEADER_CHARS);
+		printf(" ");
+	}
+	int padding = LEFT_COL_SPACE - pos - strlen(type);
+	if (!pos) {
+		padding += 3;
+	}
+	printf("%s %*c %4d  %4d  [%p]\n", type, padding, ' ', x, y, node);
+
+	if ((IGNORE_MENU && node == &server->menu_tree->node)
+			|| (IGNORE_SSD && view && view->ssd.tree
+			&& node == &view->ssd.tree->node)) {
+		printf("%*c%s\n", pos + 4 + INDENT_SIZE, ' ', "<skipping children>");
+		return;
+	}
+	struct wlr_scene_node *child;
+	wl_list_for_each(child, &node->state.children, state.link) {
+		dump_tree(server, child, pos + INDENT_SIZE,
+			x + child->state.x, y + child->state.y);
 	}
 }
 
 void
 debug_dump_scene(struct server *server)
 {
-	struct wlr_scene_node *node;
-
-	printf(":: view_tree ::\n");
-	node = &server->view_tree->node;
-	dump_tree(node, 0, node->state.x, node->state.y);
-
-	printf(":: layer_tree ::\n");
-	struct output *output;
-	wl_list_for_each(output, &server->outputs, link) {
-		for (int i = 0; i < 4; i++) {
-			node = &output->layer_tree[i]->node;
-			printf("layer-%s\n", get_layer_name(i));
-			dump_tree(node, 0, node->state.x, node->state.y);
-		}
-	}
-
-	printf(":: osd_tree ::\n");
-	node = &server->osd_tree->node;
-	dump_tree(node, 0, node->state.x, node->state.y);
-
-	printf(":: menu_tree ::\n");
-	node = &server->menu_tree->node;
-	dump_tree(node, 0, node->state.x, node->state.y);
+	printf("\n");
+	dump_tree(server, &server->scene->node, 0, 0, 0);
+	printf("\n");
 }


### PR DESCRIPTION
Branch is based on PR #5, will rebase once that one is merged.
Only relevant commit in this PR is d1409f8b40338295b4a4b433401791ec0201e4fa ([File](https://github.com/johanmalm/labwc/blob/d1409f8b40338295b4a4b433401791ec0201e4fa/src/debug.c))

Also added three more config defines on top:
- `LEFT_COL_SPACE`
- `IGNORE_SSD`
- `IGNORE_MENU`

Example output:
```
                                            X     Y        Node
                                         ----  ----  ----------------
 server->scene                              0     0  [0xaaaaaabcc700]
   +-- layer-background                     0     0  [0xaaaaaac03250]
   +-- layer-bottom                         0     0  [0xaaaaaac03370]
   +-- server->view_tree                    0     0  [0xaaaaaabcc7a0]
      +-- view                            162   134  [0xaaaaaada3410]
         +-- view->ssd                    162   134  [0xaaaaaada3c60]
                <skipping children>
         +-- view->scene_node             162   134  [0xaaaaaada3510]
            +-- tree                      162   134  [0xaaaaaada3660]
               +-- surface                162   134  [0xaaaaaada36c0]
   +-- server->unmanaged_tree               0     0  [0xaaaaaabcd290]
   +-- server->menu_tree                    0     0  [0xaaaaaabcd2f0]
          <skipping children>
   +-- server->osd_tree                     0     0  [0xaaaaaabcd350]
   +-- layer-top                            0     0  [0xaaaaaac03490]
   +-- layer-overlay                        0     0  [0xaaaaaac035b0]
```