### PR TITLE
find-indents.c - nested comments

### DIFF
--- a/scripts/helper/find-idents.c
+++ b/scripts/helper/find-idents.c
@@ -54,6 +54,7 @@ enum {
 	SPECIAL_COMPARISON_OP,
 	SPECIAL_COMMENT_BEGIN,
 	SPECIAL_COMMENT_END,
+	SPECIAL_COMMENT_LINE_BEGIN,
 };
 
 static char *current_buffer_position;
@@ -114,6 +115,7 @@ add_token(void)
 static void
 handle_whitespace(struct token *token)
 {
+	return;
 	if (current_buffer_position[0] == '\n') {
 		++current_line;
 	}
@@ -198,6 +200,7 @@ struct {
 	{ "!=", SPECIAL_COMPARISON_OP },
 	{ "/*", SPECIAL_COMMENT_BEGIN },
 	{ "*/", SPECIAL_COMMENT_END },
+	{ "//", SPECIAL_COMMENT_LINE_BEGIN },
 	{ ";", ';' },
 	{ "{", '{' },
 	{ "}", '}' },
@@ -282,6 +285,7 @@ lex(char *buffer)
 	tokens = NULL;
 	nr_tokens = 0;
 	alloc_tokens = 0;
+	bool in_single_comment = false;
 
 	current_buffer_position = buffer;
 
@@ -309,11 +313,21 @@ lex(char *buffer)
 			token = add_token();
 			get_special_token(token);
 			token->kind = TOKEN_SPECIAL;
+			if (token->special == SPECIAL_COMMENT_LINE_BEGIN) {
+				token->special = SPECIAL_COMMENT_BEGIN;
+				in_single_comment = true;
+			}
 			continue;
 		case '#':
 			handle_preprocessor_directive();
 			break;
 		case '\n':
+			if (in_single_comment) {
+				token = add_token();
+				token->kind = TOKEN_SPECIAL;
+				token->special = SPECIAL_COMMENT_END;
+				in_single_comment = false;
+			}
 			++current_line;
 			break;
 		default:
@@ -350,14 +364,14 @@ static bool
 grep(struct token *tokens, const char *pattern)
 {
 	bool found = false;
-	bool in_comment = false;
+	unsigned int in_comment = 0;
 
 	for (struct token *t = tokens; t->kind; t++) {
 		if (t->kind == TOKEN_SPECIAL) {
 			if (t->special == SPECIAL_COMMENT_BEGIN) {
-				in_comment = true;
+				++in_comment;
 			} else if (t->special == SPECIAL_COMMENT_END) {
-				in_comment = false;
+				--in_comment;
 			}
 		}
 		if (in_comment) {

--- a/scripts/helper/find-idents.c
+++ b/scripts/helper/find-idents.c
@@ -54,7 +54,6 @@ enum {
 	SPECIAL_COMPARISON_OP,
 	SPECIAL_COMMENT_BEGIN,
 	SPECIAL_COMMENT_END,
-	SPECIAL_COMMENT_LINE,
 };
 
 static char *current_buffer_position;
@@ -199,7 +198,6 @@ struct {
 	{ "!=", SPECIAL_COMPARISON_OP },
 	{ "/*", SPECIAL_COMMENT_BEGIN },
 	{ "*/", SPECIAL_COMMENT_END },
-	{ "//", SPECIAL_COMMENT_LINE },
 	{ ";", ';' },
 	{ "{", '{' },
 	{ "}", '}' },
@@ -278,21 +276,6 @@ handle_preprocessor_directive(void)
 	}
 }
 
-static void
-ignore_until_end_of_line(void)
-{
-	for (;;) {
-		++current_buffer_position;
-		if (current_buffer_position[0] == '\0') {
-			return;
-		}
-		if (current_buffer_position[0] == '\n') {
-			/* current_line will be incremented in lex() */
-			return;
-		}
-	}
-}
-
 struct token *
 lex(char *buffer)
 {
@@ -326,9 +309,6 @@ lex(char *buffer)
 			token = add_token();
 			get_special_token(token);
 			token->kind = TOKEN_SPECIAL;
-			if (token->special == SPECIAL_COMMENT_LINE) {
-				ignore_until_end_of_line();
-			}
 			continue;
 		case '#':
 			handle_preprocessor_directive();


### PR DESCRIPTION
Lets try to create a PR to a branch that is used for a PR in another repo :)
This PR is just meant for discussion, so we don't unnecessarily trigger notifications in the labwc repo.

This variant for handling single line commits should solve the issue [described earlier](https://github.com/labwc/labwc/pull/741#issuecomment-1423556521):
```c
/* this is a // nested comment */
```
Which would cause `*/` to be missed because we'd ignore everything until the end of the line and thus everything after this one is determined to be a comment until seeing another unrelated `*/` somewhere else.

To make it work properly I had to stub out `handle_whitespace()` (so the main switch can handle `\n` and create a comment-end token when in single comment mode) which may have further implications but I didn't really look into those so far.
This also converts the `bool in_comment` in `grep()` to a counter which gets increased / decreased every time a new comment start / end token is encountered, thus supporting nested comments.